### PR TITLE
Update 'good_omen' translation for Korean

### DIFF
--- a/www/src/translation.ts
+++ b/www/src/translation.ts
@@ -244,7 +244,7 @@ const dictionary: {[key: string]: DictionaryEntry} = {
     GOOD_OMEN: {
         en: "Good Omen",
         ja: "良兆候",
-        ko: "좋은 징후",  // todo: fix this once 6.4 is released in Korean servers.
+        ko: "길조",
     },
 
     // buffs


### PR DESCRIPTION
https://twitter.com/monghoho/status/1702902431074636029/photo/1

The translation of 'good_omen' is '길조' from today's KR letter live.
So, update the translation.