### PR TITLE
Speed up macro annealing by ~6x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,17 @@ path = "src/macro_experiment.rs"
 name = "gen_macro"
 path = "src/gen_macro.rs"
 
+[[bin]]
+name = "bench"
+path = "src/bench.rs"
+
 [features]
 default = ["console_error_panic_hook"]
 
 [dependencies]
 wasm-bindgen = "0.2.88"
 num = "0.4.0"
-rand = "0.8.4"
+rand = { version = "0.8.4", features = ["small_rng"] }
 getrandom = { version = "0.2.3", features = ["js"] }
 lazy_static = "1.4.0"
 rayon = "1.5.1"

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use crate::state::{CraftParameter, CraftResult, CraftState, StatusCondition};
-use crate::factor::{transition_probabilities, progress_div, crafting_level, progress_mod, quality_div, quality_mod};
+use crate::factor::{transition_probabilities, Factors};
 use strum_macros::{EnumString, AsRefStr};
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash, Debug, Deserialize, Serialize, EnumString, AsRefStr)]
@@ -110,13 +110,57 @@ fn tick(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
     result
 }
 
+/// `tick`, specialised to a caller that pins the condition to NORMAL.
+///
+/// Mirrors `tick` line for line up to the point where `tick` splits into one
+/// state per status condition; those states differ only in `condition`, so
+/// pinning it here yields the same result without the HashMap, the sort and the
+/// per-condition clones.
+fn tick_normal(params: &CraftParameter, state: &mut CraftState) {
+    debug_assert!(state.result == CraftResult::ONGOING);
+    debug_assert!(state.cp >= 0);
+
+    state.clip(params);
+    state.advanced_touch_ready = state.standard_touch_ready && (state.prev_action == Some(CraftAction::StandardTouch) || state.prev_action == Some(CraftAction::Observe));
+    state.standard_touch_ready = state.prev_action == Some(CraftAction::BasicTouch);
+    state.condition = StatusCondition::NORMAL;
+
+    if state.prev_action == Some(CraftAction::FinalAppraisal) {
+        return;
+    }
+
+    if state.progress >= params.item.max_progress {
+        if state.final_appraisal <= 0 {
+            state.result = CraftResult::SUCCESS;
+            return;
+        } else {
+            state.final_appraisal = 0;
+            state.progress = params.item.max_progress - 1;
+        }
+    }
+
+    if state.durability <= 0 {
+        state.result = CraftResult::FAILED;
+        return;
+    }
+
+    state.innovation -= 1;
+    state.veneration -= 1;
+    state.muscle_memory -= 1;
+    state.waste_not -= 1;
+    state.great_strides -= 1;
+    state.final_appraisal -= 1;
+    if state.manipulation > 0 && (state.prev_action.is_none() || state.prev_action.unwrap() != CraftAction::Manipulation) {
+        state.durability += 5;
+    }
+    state.manipulation -= 1;
+    state.expedience -= 1;
+    state.turn += 1;
+    state.clip(params);
+}
+
 // https://docs.google.com/document/d/1Fl5X16oPF-4X29v5PukCkVgcPhZsbzhKcoq6Us7fhKU/edit#
-fn produce_progress(params: &CraftParameter, state: &mut CraftState, base_efficiency: f64) {
-    let crafting_level = crafting_level(params.player.job_level);
-    let recipe_level = params.item.recipe_level;
-    let p1 = params.player.craftsmanship as f64 * 10. / progress_div(recipe_level) as f64 + 2.;
-    let penalty = if crafting_level <= recipe_level { progress_mod(recipe_level) as f64 / 100. } else { 1. };
-    let p2 = p1 * penalty;
+fn produce_progress(factors: &Factors, state: &mut CraftState, base_efficiency: f64) {
     let condition = if state.condition == StatusCondition::MALLEABLE { 1.5 } else { 1. };
     let mut buffs = 1.;
     if state.veneration > 0 {
@@ -126,18 +170,13 @@ fn produce_progress(params: &CraftParameter, state: &mut CraftState, base_effici
         buffs += 1.;
     }
     let efficiency = base_efficiency * buffs;
-    let progress = ((p2 as i64) as f64 * condition * efficiency / 100.) as i64;
+    let progress = (factors.progress_base * condition * efficiency / 100.) as i64;
 
     state.progress += progress;
     state.muscle_memory = 0;
 }
 
-fn produce_quality(params: &CraftParameter, state: &mut CraftState, base_efficiency: f64, inner_quiet_progress: i64) {
-    let crafting_level = crafting_level(params.player.job_level);
-    let recipe_level = params.item.recipe_level;
-    let q1 = params.player.control as f64 * 10. / quality_div(recipe_level) as f64 + 35.;
-    let penalty = if crafting_level <= recipe_level { quality_mod(recipe_level) as f64 / 100. } else { 1. };
-    let q2 = q1 * penalty;
+fn produce_quality(factors: &Factors, state: &mut CraftState, base_efficiency: f64, inner_quiet_progress: i64) {
     let condition = if state.condition == StatusCondition::POOR {
         0.5
     } else if state.condition == StatusCondition::GOOD {
@@ -156,7 +195,7 @@ fn produce_quality(params: &CraftParameter, state: &mut CraftState, base_efficie
     }
 
     let efficiency = base_efficiency * (1. + state.inner_quiet as f64 / 10.) * buffs;
-    let quality = ((q2 as i64) as f64 * condition * efficiency / 100.) as i64;
+    let quality = (factors.quality_base * condition * efficiency / 100.) as i64;
 
     state.quality += quality as i64;
     state.inner_quiet += inner_quiet_progress;
@@ -173,222 +212,147 @@ pub fn buff_turns(state: &CraftState, base_turn: i64) -> i64 {
     }
 }
 
-fn binary_result_states(success_result: CraftState, failed_result: CraftState, current_state: &CraftState, base_success_proba: f64) -> ProbabilisticResult {
-    let success_proba = base_success_proba + if current_state.condition == StatusCondition::CENTRED { 0.25 } else { 0. };
-    return vec![
-        ProbabilisticState { probability: success_proba, state: success_result },
-        ProbabilisticState { probability: 1. - success_proba, state: failed_result }
-    ];
-}
-
-fn apply_basic_synthesis(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
+fn apply_basic_synthesis(params: &CraftParameter, factors: &Factors, state: &mut CraftState) {
     let efficiency = if params.player.job_level >= 31 { 120. } else { 100. };
-    produce_progress(params, &mut next_state, efficiency);
-    deterministic(next_state)
+    produce_progress(factors, state, efficiency);
 }
 
-fn apply_basic_touch(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    produce_quality(params, &mut next_state, 100., 1);
-    deterministic(next_state)
+fn apply_basic_touch(factors: &Factors, state: &mut CraftState) {
+    produce_quality(factors, state, 100., 1);
 }
 
-fn apply_masters_mend(state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    next_state.durability += 30;
-    deterministic(next_state)
+fn apply_masters_mend(state: &mut CraftState) {
+    state.durability += 30;
 }
 
-fn apply_delicate_synthesis(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
+fn apply_delicate_synthesis(params: &CraftParameter, factors: &Factors, state: &mut CraftState) {
     let progress_efficiency = if params.player.job_level >= 94 { 150. } else { 100. };
-    produce_progress(params, &mut next_state, progress_efficiency);
-    produce_quality(params, &mut next_state, 100., 1);
-    deterministic(next_state)
+    produce_progress(factors, state, progress_efficiency);
+    produce_quality(factors, state, 100., 1);
 }
 
-fn apply_careful_synthesis(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
+fn apply_careful_synthesis(params: &CraftParameter, factors: &Factors, state: &mut CraftState) {
     let efficiency = if params.player.job_level >= 82 { 180. } else { 150. };
-    produce_progress(params, &mut next_state, efficiency);
-    deterministic(next_state)
+    produce_progress(factors, state, efficiency);
 }
 
-fn apply_groundwork(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
+fn apply_groundwork(params: &CraftParameter, factors: &Factors, state: &mut CraftState) {
     let base_efficiency = if params.player.job_level >= 86 { 360. } else { 300. };
     let efficiency = if state.durability < 0 { base_efficiency / 2. } else { base_efficiency };
-    produce_progress(params, &mut next_state, efficiency);
-    deterministic(next_state)
+    produce_progress(factors, state, efficiency);
 }
 
-fn apply_observe(state: &CraftState) -> ProbabilisticResult {
-    deterministic(state.clone())
-}
+fn apply_observe(_state: &mut CraftState) {}
 
-fn apply_byregot_blessing(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
+fn apply_byregot_blessing(factors: &Factors, state: &mut CraftState) {
     let efficiency = 20. * state.inner_quiet as f64 + 100.;
-    produce_quality(params, &mut next_state, efficiency, 0);
-    next_state.inner_quiet = 0;
-    deterministic(next_state)
+    produce_quality(factors, state, efficiency, 0);
+    state.inner_quiet = 0;
 }
 
-fn apply_preparatory_touch(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    produce_quality(params, &mut next_state, 200., 2);
-    deterministic(next_state)
+fn apply_preparatory_touch(factors: &Factors, state: &mut CraftState) {
+    produce_quality(factors, state, 200., 2);
 }
 
-fn apply_rapid_synthesis(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let failed_state = state.clone();
-    let mut success_state = state.clone();
+fn apply_rapid_synthesis(params: &CraftParameter, factors: &Factors, state: &mut CraftState) {
     let efficiency = if params.player.job_level >= 63 { 500. } else { 250. };  // todo: check if this number is correct
-    produce_progress(params, &mut success_state, efficiency);
-    binary_result_states(success_state, failed_state, state, 0.5)
+    produce_progress(factors, state, efficiency);
 }
 
-fn apply_intensive_synthesis(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    produce_progress(params, &mut next_state, 400.);
-    return deterministic(next_state);
+fn apply_intensive_synthesis(factors: &Factors, state: &mut CraftState) {
+    produce_progress(factors, state, 400.);
 }
 
-fn apply_hasty_touch(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let failed_state = state.clone();
-    let mut success_state = state.clone();
-    produce_quality(params, &mut success_state, 100., 1);
+fn apply_hasty_touch(params: &CraftParameter, factors: &Factors, state: &mut CraftState) {
+    produce_quality(factors, state, 100., 1);
     if params.player.job_level >= 96 {
-        success_state.expedience = 1 + 1;
+        state.expedience = 1 + 1;
     }
-    return binary_result_states(success_state, failed_state, state, 0.6);
 }
 
-fn apply_precise_touch(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    produce_quality(params, &mut next_state, 150., 2);
-    deterministic(next_state)
+fn apply_precise_touch(factors: &Factors, state: &mut CraftState) {
+    produce_quality(factors, state, 150., 2);
 }
 
-fn apply_tricks_of_the_trade(state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    next_state.cp += 20;
-    deterministic(next_state)
+fn apply_tricks_of_the_trade(state: &mut CraftState) {
+    state.cp += 20;
 }
 
-fn apply_innovation(state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    next_state.innovation = buff_turns(state, 4) + 1;
-    deterministic(next_state)
+fn apply_innovation(state: &mut CraftState) {
+    state.innovation = buff_turns(state, 4) + 1;
 }
 
-fn apply_veneration(state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    next_state.veneration = buff_turns(state, 4) + 1;
-    deterministic(next_state)
+fn apply_veneration(state: &mut CraftState) {
+    state.veneration = buff_turns(state, 4) + 1;
 }
 
-fn apply_muscle_memory(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    produce_progress(params, &mut next_state, 300.);
-    next_state.muscle_memory = buff_turns(state, 5) + 1;
-    deterministic(next_state)
+fn apply_muscle_memory(factors: &Factors, state: &mut CraftState) {
+    let muscle_memory = buff_turns(state, 5) + 1;
+    produce_progress(factors, state, 300.);
+    state.muscle_memory = muscle_memory;
 }
 
-
-fn apply_standard_touch(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    produce_quality(params, &mut next_state, 125., 1);
-    deterministic(next_state)
+fn apply_standard_touch(factors: &Factors, state: &mut CraftState) {
+    produce_quality(factors, state, 125., 1);
 }
 
-fn apply_reflect(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    produce_quality(params, &mut next_state, 300., 0);
-    next_state.inner_quiet = 2;
-    deterministic(next_state)
+fn apply_reflect(factors: &Factors, state: &mut CraftState) {
+    produce_quality(factors, state, 300., 0);
+    state.inner_quiet = 2;
 }
 
-fn apply_waste_not(state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    next_state.waste_not = buff_turns(state, 4) + 1;
-    deterministic(next_state)
+fn apply_waste_not(state: &mut CraftState) {
+    state.waste_not = buff_turns(state, 4) + 1;
 }
 
-fn apply_waste_not_ii(state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    next_state.waste_not = buff_turns(state, 8) + 1;
-    deterministic(next_state)
+fn apply_waste_not_ii(state: &mut CraftState) {
+    state.waste_not = buff_turns(state, 8) + 1;
 }
 
-fn apply_prudent_touch(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    produce_quality(params, &mut next_state, 100., 1);
-    deterministic(next_state)
+fn apply_prudent_touch(factors: &Factors, state: &mut CraftState) {
+    produce_quality(factors, state, 100., 1);
 }
 
-fn apply_great_strides(state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    next_state.great_strides = buff_turns(state, 3) + 1;
-    deterministic(next_state)
+fn apply_great_strides(state: &mut CraftState) {
+    state.great_strides = buff_turns(state, 3) + 1;
 }
 
-fn apply_final_appraisal(state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    next_state.final_appraisal = buff_turns(state, 5);
-    deterministic(next_state)
+fn apply_final_appraisal(state: &mut CraftState) {
+    state.final_appraisal = buff_turns(state, 5);
 }
 
-fn apply_manipulation(state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    next_state.manipulation = buff_turns(state, 8) + 1;
-    deterministic(next_state)
+fn apply_manipulation(state: &mut CraftState) {
+    state.manipulation = buff_turns(state, 8) + 1;
 }
 
-fn apply_advanced_touch(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    produce_quality(params, &mut next_state, 150., 1);
-    deterministic(next_state)
+fn apply_advanced_touch(factors: &Factors, state: &mut CraftState) {
+    produce_quality(factors, state, 150., 1);
 }
 
-fn apply_prudent_synthesis(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    produce_progress(params, &mut next_state, 180.);
-    deterministic(next_state)
+fn apply_prudent_synthesis(factors: &Factors, state: &mut CraftState) {
+    produce_progress(factors, state, 180.);
 }
 
-fn apply_trained_finesse(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    produce_quality(params, &mut next_state, 100., 1);
-    deterministic(next_state)
+fn apply_trained_finesse(factors: &Factors, state: &mut CraftState) {
+    produce_quality(factors, state, 100., 1);
 }
 
-fn apply_refined_touch(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
+fn apply_refined_touch(factors: &Factors, state: &mut CraftState) {
     let inner_quiet_progress = if state.standard_touch_ready { 2 } else { 1 };
-    produce_quality(params, &mut next_state, 100., inner_quiet_progress);
-    deterministic(next_state)
+    produce_quality(factors, state, 100., inner_quiet_progress);
 }
 
-fn apply_daring_touch(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let failed_state = state.clone();
-    let mut success_state = state.clone();
-    produce_quality(params, &mut success_state, 150., 1);
-    return binary_result_states(success_state, failed_state, state, 0.6);
+fn apply_daring_touch(factors: &Factors, state: &mut CraftState) {
+    produce_quality(factors, state, 150., 1);
 }
 
-fn apply_immaculate_mend(params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    next_state.durability = params.item.max_durability;
-    deterministic(next_state)
+fn apply_immaculate_mend(params: &CraftParameter, state: &mut CraftState) {
+    state.durability = params.item.max_durability;
 }
 
-fn apply_trained_perfection(state: &CraftState) -> ProbabilisticResult {
-    let mut next_state = state.clone();
-    next_state.trained_perfection = 1;
-    next_state.trained_perfection_remain -= 1;
-    deterministic(next_state)
+fn apply_trained_perfection(state: &mut CraftState) {
+    state.trained_perfection = 1;
+    state.trained_perfection_remain -= 1;
 }
 
 impl CraftAction {
@@ -555,54 +519,98 @@ impl CraftAction {
         }
     }
 
-    pub fn apply(&self, params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
-        let mut state = state.clone();
-        state.cp -= self.cp_cost(&state);
-        state.durability -= self.durability_cost(&state);
+    /// Probability that the action takes effect. Only Rapid Synthesis, Hasty
+    /// Touch and Daring Touch can fail; everything else always succeeds.
+    fn success_probability(&self, state: &CraftState) -> f64 {
+        let base_success_proba = match self {
+            Self::RapidSynthesis => 0.5,
+            Self::HastyTouch | Self::DaringTouch => 0.6,
+            _ => return 1.,
+        };
+        base_success_proba + if state.condition == StatusCondition::CENTRED { 0.25 } else { 0. }
+    }
+
+    /// Pays the action's CP and durability cost and records it as the previous
+    /// action. Must run before `apply_effect`, which reads the paid-up state.
+    fn pay_costs(&self, state: &mut CraftState) {
+        state.cp -= self.cp_cost(state);
+        state.durability -= self.durability_cost(state);
         if self.base_durability_cost() > 0 && state.trained_perfection > 0 {
             state.trained_perfection -= 1;
         }
         state.prev_action = Some(*self);
+    }
 
+    /// Applies the action's effect in place, assuming it succeeds. Both the
+    /// probabilistic and the deterministic simulation paths go through here, so
+    /// action behaviour lives in exactly one place.
+    fn apply_effect(&self, params: &CraftParameter, factors: &Factors, state: &mut CraftState) {
         match self {
-            Self::BasicSynthesis => apply_basic_synthesis(params, &state),
-            Self::BasicTouch => apply_basic_touch(params, &state),
-            Self::MastersMend => apply_masters_mend(&state),
-            Self::DelicateSynthesis => apply_delicate_synthesis(params, &state),
-            Self::CarefulSynthesis => apply_careful_synthesis(params, &state),
-            Self::Groundwork => apply_groundwork(params, &state),
-            Self::Observe => apply_observe(&state),
-            Self::ByregotBlessing => apply_byregot_blessing(params, &state),
-            Self::PreparatoryTouch => apply_preparatory_touch(params, &state),
-            Self::RapidSynthesis => apply_rapid_synthesis(params, &state),
-            Self::IntensiveSynthesis => apply_intensive_synthesis(params, &state),
-            Self::HastyTouch => apply_hasty_touch(params, &state),
-            Self::PreciseTouch => apply_precise_touch(params, &state),
-            Self::TrickOfTheTrade => apply_tricks_of_the_trade(&state),
-            Self::Innovation => apply_innovation(&state),
-            Self::Veneration => apply_veneration(&state),
-            Self::MuscleMemory => apply_muscle_memory(params, &state),
-            Self::StandardTouch => apply_standard_touch(params, &state),
-            Self::Reflect => apply_reflect(params, &state),
-            Self::WasteNot => apply_waste_not(&state),
-            Self::WasteNotII => apply_waste_not_ii(&state),
-            Self::PrudentTouch => apply_prudent_touch(params, &state),
-            Self::GreatStrides => apply_great_strides(&state),
-            Self::FinalAppraisal => apply_final_appraisal(&state),
-            Self::Manipulation => apply_manipulation(&state),
-            Self::AdvancedTouch => apply_advanced_touch(params, &state),
-            Self::PrudentSynthesis => apply_prudent_synthesis(params, &state),
-            Self::TrainedFinesse => apply_trained_finesse(params, &state),
-            Self::RefinedTouch => apply_refined_touch(params, &state),
-            Self::DaringTouch => apply_daring_touch(params, &state),
-            Self::ImmaculateMend => apply_immaculate_mend(params, &state),
-            Self::TrainedPerfection => apply_trained_perfection(&state)
+            Self::BasicSynthesis => apply_basic_synthesis(params, factors, state),
+            Self::BasicTouch => apply_basic_touch(factors, state),
+            Self::MastersMend => apply_masters_mend(state),
+            Self::DelicateSynthesis => apply_delicate_synthesis(params, factors, state),
+            Self::CarefulSynthesis => apply_careful_synthesis(params, factors, state),
+            Self::Groundwork => apply_groundwork(params, factors, state),
+            Self::Observe => apply_observe(state),
+            Self::ByregotBlessing => apply_byregot_blessing(factors, state),
+            Self::PreparatoryTouch => apply_preparatory_touch(factors, state),
+            Self::RapidSynthesis => apply_rapid_synthesis(params, factors, state),
+            Self::IntensiveSynthesis => apply_intensive_synthesis(factors, state),
+            Self::HastyTouch => apply_hasty_touch(params, factors, state),
+            Self::PreciseTouch => apply_precise_touch(factors, state),
+            Self::TrickOfTheTrade => apply_tricks_of_the_trade(state),
+            Self::Innovation => apply_innovation(state),
+            Self::Veneration => apply_veneration(state),
+            Self::MuscleMemory => apply_muscle_memory(factors, state),
+            Self::StandardTouch => apply_standard_touch(factors, state),
+            Self::Reflect => apply_reflect(factors, state),
+            Self::WasteNot => apply_waste_not(state),
+            Self::WasteNotII => apply_waste_not_ii(state),
+            Self::PrudentTouch => apply_prudent_touch(factors, state),
+            Self::GreatStrides => apply_great_strides(state),
+            Self::FinalAppraisal => apply_final_appraisal(state),
+            Self::Manipulation => apply_manipulation(state),
+            Self::AdvancedTouch => apply_advanced_touch(factors, state),
+            Self::PrudentSynthesis => apply_prudent_synthesis(factors, state),
+            Self::TrainedFinesse => apply_trained_finesse(factors, state),
+            Self::RefinedTouch => apply_refined_touch(factors, state),
+            Self::DaringTouch => apply_daring_touch(factors, state),
+            Self::ImmaculateMend => apply_immaculate_mend(params, state),
+            Self::TrainedPerfection => apply_trained_perfection(state),
         }
     }
 
+    pub fn apply(&self, params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
+        self.apply_with(params, &Factors::new(params), state)
+    }
+
+    pub fn apply_with(&self, params: &CraftParameter, factors: &Factors, state: &CraftState) -> ProbabilisticResult {
+        let mut state = state.clone();
+        self.pay_costs(&mut state);
+
+        let success_proba = self.success_probability(&state);
+        if success_proba >= 1. {
+            self.apply_effect(params, factors, &mut state);
+            return deterministic(state);
+        }
+
+        let failed_state = state.clone();
+        let mut success_state = state;
+        self.apply_effect(params, factors, &mut success_state);
+        vec![
+            ProbabilisticState { probability: success_proba, state: success_state },
+            ProbabilisticState { probability: 1. - success_proba, state: failed_state },
+        ]
+    }
+
     pub fn play(&self, params: &CraftParameter, state: &CraftState) -> ProbabilisticResult {
+        self.play_with(params, &Factors::new(params), state)
+    }
+
+    pub fn play_with(&self, params: &CraftParameter, factors: &Factors, state: &CraftState) -> ProbabilisticResult {
         let mut result: ProbabilisticResult = vec![];
-        for applied_state in self.apply(params, state).iter() {
+        for applied_state in self.apply_with(params, factors, state).iter() {
             for ticked_state in tick(params, &applied_state.state).iter() {
                 result.push(ProbabilisticState {
                     probability: ticked_state.probability * applied_state.probability,
@@ -611,6 +619,30 @@ impl CraftAction {
             }
         }
         result
+    }
+
+    /// Plays one turn with the status condition pinned to NORMAL, allocating
+    /// nothing and computing no transition probabilities.
+    ///
+    /// This is exactly what `run_macro(.., force_normal = true)` does: the
+    /// outcomes `tick` produces differ only in their `condition` field, which
+    /// the caller immediately overwrites with NORMAL, so sampling among them is
+    /// a no-op. Returns `None` for the three actions that can genuinely fail —
+    /// there the caller must fall back to `play`.
+    pub fn play_normal(&self, params: &CraftParameter, factors: &Factors, state: &CraftState) -> Option<CraftState> {
+        if self.success_probability(state) < 1. {
+            return None;
+        }
+        let mut next_state = state.clone();
+        self.pay_costs(&mut next_state);
+        self.apply_effect(params, factors, &mut next_state);
+        tick_normal(params, &mut next_state);
+        Some(next_state)
+    }
+
+    #[cfg(test)]
+    fn is_deterministic(&self) -> bool {
+        !matches!(self, Self::RapidSynthesis | Self::HastyTouch | Self::DaringTouch)
     }
 
     pub fn all_actions() -> Vec<CraftAction> {
@@ -648,5 +680,121 @@ impl CraftAction {
             Self::ImmaculateMend,
             Self::TrainedPerfection,
         ]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use rand::prelude::SliceRandom;
+    use rand::{rngs::SmallRng, SeedableRng};
+
+    use super::*;
+    use crate::factor::Factors;
+    use crate::state::{ItemParameter, PlayerParameter};
+
+    fn craft_params(job_level: i64, recipe_level: i64) -> CraftParameter {
+        CraftParameter {
+            player: PlayerParameter {
+                job_level,
+                craftsmanship: 3252,
+                control: 3174,
+                max_cp: 577,
+                unavailable_actions: vec![],
+            },
+            item: ItemParameter {
+                recipe_level,
+                max_durability: 70,
+                max_progress: 3900,
+                max_quality: 10920,
+            },
+        }
+    }
+
+    /// The annealer's fast path assumes that pinning the status condition to
+    /// NORMAL makes a turn deterministic, because `tick`'s outcomes differ only
+    /// in their `condition` field. This walks random macros and asserts that
+    /// every outcome `play` can produce collapses onto what `play_normal`
+    /// returns, which is the property the fast path rests on.
+    #[test]
+    fn play_normal_matches_every_outcome_of_play() {
+        // 580 is a normal recipe, 641 and 516 are expert recipes.
+        let all_params = [
+            craft_params(90, 580),
+            craft_params(100, 580),
+            craft_params(100, 641),
+            craft_params(80, 516),
+            craft_params(62, 390),
+        ];
+
+        let mut checked_turns = 0;
+        for params in all_params.iter() {
+            let factors = Factors::new(params);
+            let candidates: Vec<CraftAction> = CraftAction::all_actions()
+                .into_iter()
+                .filter(|action| params.player.job_level >= action.action_level())
+                .filter(|action| action.is_deterministic())
+                .collect();
+
+            for seed in 0..300u64 {
+                let mut rng = SmallRng::seed_from_u64(seed);
+                let mut state = params.initial_state(0);
+
+                for _ in 0..60 {
+                    if state.result != CraftResult::ONGOING {
+                        break;
+                    }
+                    let action = *candidates.choose(&mut rng).unwrap();
+                    if !action.is_playable(params, &state) {
+                        state.turn += 1;
+                        continue;
+                    }
+
+                    let fast = action
+                        .play_normal(params, &factors, &state)
+                        .expect("deterministic action must take the fast path");
+                    let outcomes = action.play(params, &state);
+                    assert!(!outcomes.is_empty());
+                    for proba_state in outcomes.iter() {
+                        let mut pinned = proba_state.state.clone();
+                        pinned.condition = StatusCondition::NORMAL;
+                        assert_eq!(
+                            pinned, fast,
+                            "mismatch for {:?} at turn {} (rlv {})",
+                            action, state.turn, params.item.recipe_level
+                        );
+                    }
+
+                    checked_turns += 1;
+                    state = fast;
+                }
+            }
+        }
+        assert!(checked_turns > 10_000, "weak coverage: {} turns", checked_turns);
+    }
+
+    /// `apply` must still describe the same distribution for the actions that
+    /// can fail, which no longer go through a dedicated `binary_result_states`.
+    #[test]
+    fn failing_actions_keep_their_probabilities() {
+        let params = craft_params(100, 580);
+        let mut state = params.initial_state(0);
+        state.prev_action = Some(CraftAction::BasicSynthesis);
+        state.expedience = 2;
+
+        for (action, expected) in [
+            (CraftAction::RapidSynthesis, 0.5),
+            (CraftAction::HastyTouch, 0.6),
+            (CraftAction::DaringTouch, 0.6),
+        ] {
+            for (condition, bonus) in [(StatusCondition::NORMAL, 0.), (StatusCondition::CENTRED, 0.25)] {
+                let mut state = state.clone();
+                state.condition = condition;
+                let outcomes = action.apply(&params, &state);
+                assert_eq!(outcomes.len(), 2, "{:?}", action);
+                assert!((outcomes[0].probability - (expected + bonus)).abs() < 1e-9, "{:?}", action);
+                assert!((outcomes[1].probability - (1. - expected - bonus)).abs() < 1e-9, "{:?}", action);
+                assert!(action.play_normal(&params, &Factors::new(&params), &state).is_none());
+            }
+        }
     }
 }

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,0 +1,203 @@
+use std::hint::black_box;
+use std::time::Instant;
+
+use crate::action::CraftAction;
+use crate::action::CraftAction::*;
+use rand::{rngs::SmallRng, SeedableRng};
+
+use crate::factor::{crafting_level, progress_div, progress_mod, quality_div, quality_mod, transition_probabilities, Factors};
+use crate::macroplan::{run_macro, plan_with_annealing_params, AnnealingParams};
+use crate::state::{CraftParameter, CraftState, ItemParameter, PlayerParameter};
+
+mod action;
+mod factor;
+mod macroplan;
+mod search;
+mod state;
+
+fn params() -> CraftParameter {
+    CraftParameter {
+        player: PlayerParameter {
+            job_level: 90,
+            craftsmanship: 3252,
+            control: 3174,
+            max_cp: 577,
+            unavailable_actions: vec![],
+        },
+        item: ItemParameter {
+            recipe_level: 580,
+            max_durability: 70,
+            max_progress: 3900,
+            max_quality: 10920,
+        },
+    }
+}
+
+/// A representative macro produced by the annealer for the parameters above.
+fn sample_macro() -> Vec<CraftAction> {
+    vec![
+        MuscleMemory, Manipulation, Veneration, WasteNotII, Groundwork, Groundwork,
+        BasicTouch, StandardTouch, Innovation, PreparatoryTouch, PreparatoryTouch,
+        BasicTouch, StandardTouch, Innovation, DelicateSynthesis, AdvancedTouch,
+        GreatStrides, ByregotBlessing, BasicSynthesis,
+    ]
+}
+
+fn bench_run_macro(params: &CraftParameter) {
+    let actions = sample_macro();
+    let turns = actions.len();
+    let iters = 200_000;
+
+    // warm up
+    let mut sink: i64 = 0;
+    for _ in 0..10_000 {
+        sink += run_macro(params, &actions, 0, true).quality;
+    }
+
+    let start = Instant::now();
+    for _ in 0..iters {
+        sink += run_macro(params, &actions, 0, true).quality;
+    }
+    let elapsed = start.elapsed().as_secs_f64();
+
+    println!(
+        "run_macro   : {:>8.0} ns/call  {:>6.1} ns/turn   ({:.2}s / {} iters, sink={})",
+        elapsed / iters as f64 * 1e9,
+        elapsed / (iters * turns) as f64 * 1e9,
+        elapsed,
+        iters,
+        sink
+    );
+}
+
+fn default_annealing_params(steps: i64) -> AnnealingParams {
+    AnnealingParams {
+        steps,
+        max_quality_scaling: 1.1,
+        start_temperature: 0.01,
+        end_temperature: 0.00005,
+        add_proba: 0.3,
+        remove_proba: 0.3,
+        swap_proba: 0.35,
+    }
+}
+
+fn bench_annealing(params: &CraftParameter) {
+    let steps = 200_000;
+    let annealing_params = default_annealing_params(steps);
+
+    let start = Instant::now();
+    let result = plan_with_annealing_params(params, 0, &annealing_params);
+    let elapsed = start.elapsed().as_secs_f64();
+
+    println!(
+        "annealing   : {:>8.0} ns/step  ({:.2}s / {} steps, result len={})",
+        elapsed / steps as f64 * 1e9,
+        elapsed,
+        steps,
+        result.len()
+    );
+}
+
+/// A mid-craft state: 10 actions into the sample macro.
+fn mid_state(params: &CraftParameter) -> CraftState {
+    let prefix: Vec<CraftAction> = sample_macro()[..10].to_vec();
+    run_macro(params, &prefix, 0, true)
+}
+
+fn time_it<F: FnMut()>(label: &str, iters: u64, per_turn_calls: f64, mut f: F) {
+    for _ in 0..iters / 10 {
+        f();
+    }
+    let start = Instant::now();
+    for _ in 0..iters {
+        f();
+    }
+    let ns = start.elapsed().as_secs_f64() / iters as f64 * 1e9;
+    println!(
+        "  {:<28}: {:>7.1} ns/call  x{:<4} = {:>6.1} ns/turn",
+        label,
+        ns,
+        per_turn_calls,
+        ns * per_turn_calls
+    );
+}
+
+/// Breaks a single simulated turn down into its components. The `x N` column is
+/// how many times each is invoked per turn of `run_macro`.
+fn bench_breakdown(params: &CraftParameter) {
+    let state = mid_state(params);
+    println!("turn breakdown (state: turn={}, iq={}, cp={}):", state.turn, state.inner_quiet, state.cp);
+
+    time_it("CraftState::clone", 2_000_000, 8., || {
+        black_box(black_box(&state).clone());
+    });
+    time_it("is_playable", 2_000_000, 1., || {
+        black_box(BasicTouch.is_playable(black_box(params), black_box(&state)));
+    });
+    time_it("factor table lookups", 2_000_000, 6., || {
+        black_box(
+            crafting_level(black_box(90))
+                + progress_div(black_box(580))
+                + progress_mod(black_box(580))
+                + quality_div(black_box(580))
+                + quality_mod(black_box(580)),
+        );
+    });
+    time_it("transition_probabilities", 2_000_000, 1., || {
+        black_box(transition_probabilities(black_box(params), black_box(&state)));
+    });
+    // was called once per `tweak` (i.e. once per annealing step) before hoisting
+    time_it("available_actions", 1_000_000, 1., || {
+        black_box(macroplan::available_actions(black_box(params)));
+    });
+    let factors = Factors::new(params);
+    time_it("play_normal (BasicTouch)", 2_000_000, 1., || {
+        black_box(BasicTouch.play_normal(black_box(params), black_box(&factors), black_box(&state)));
+    });
+    time_it("apply (BasicTouch)", 1_000_000, 1., || {
+        black_box(BasicTouch.apply(black_box(params), black_box(&state)));
+    });
+    time_it("play (BasicTouch)", 1_000_000, 1., || {
+        black_box(BasicTouch.play(black_box(params), black_box(&state)));
+    });
+
+    // once per annealing step, alongside one `run_macro`
+    let annealing_params = default_annealing_params(1);
+    let available = macroplan::available_actions(params);
+    let actions = sample_macro();
+    let mut rng = SmallRng::seed_from_u64(0);
+    let mut buffer: Vec<CraftAction> = Vec::with_capacity(64);
+    time_it("tweak", 2_000_000, 1., || {
+        macroplan::tweak(&available, &actions, &state, &annealing_params, &mut rng, &mut buffer);
+        black_box(&buffer);
+    });
+}
+
+/// The DFS shares `apply` / `play` with the annealer, so it needs watching for
+/// regressions. Uses a fixed depth rather than `adaptive_dfs`, whose runtime is
+/// self-limiting and therefore useless as a benchmark.
+fn bench_dfs(params: &CraftParameter) {
+    let state = params.initial_state(0);
+    let depth = 5;
+
+    let start = Instant::now();
+    let result = search::dfs(params, &state, depth);
+    let elapsed = start.elapsed().as_secs_f64();
+
+    println!(
+        "dfs(depth={}) : {:>8.3} s   (score={:.6}, first={:?})",
+        depth,
+        elapsed,
+        result.best_score,
+        result.best_action_path.first()
+    );
+}
+
+fn main() {
+    let params = params();
+    bench_breakdown(&params);
+    bench_run_macro(&params);
+    bench_annealing(&params);
+    bench_dfs(&params);
+}

--- a/src/factor.rs
+++ b/src/factor.rs
@@ -631,6 +631,39 @@ lazy_static! {
     ]));
 }  
 
+/// Progress and quality base values, which depend only on `CraftParameter`.
+///
+/// Deriving these costs five `HashMap` lookups, and `produce_progress` /
+/// `produce_quality` used to redo them on every simulated turn. Computing them
+/// once per craft and passing them down keeps the hash lookups out of the
+/// simulation loop.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Factors {
+    /// `p2` truncated to an integer, as the progress formula does.
+    pub progress_base: f64,
+    /// `q2` truncated to an integer, as the quality formula does.
+    pub quality_base: f64,
+}
+
+impl Factors {
+    pub fn new(params: &CraftParameter) -> Factors {
+        let crafting_level = crafting_level(params.player.job_level);
+        let recipe_level = params.item.recipe_level;
+        let is_penalised = crafting_level <= recipe_level;
+
+        let p1 = params.player.craftsmanship as f64 * 10. / progress_div(recipe_level) as f64 + 2.;
+        let progress_penalty = if is_penalised { progress_mod(recipe_level) as f64 / 100. } else { 1. };
+
+        let q1 = params.player.control as f64 * 10. / quality_div(recipe_level) as f64 + 35.;
+        let quality_penalty = if is_penalised { quality_mod(recipe_level) as f64 / 100. } else { 1. };
+
+        Factors {
+            progress_base: ((p1 * progress_penalty) as i64) as f64,
+            quality_base: ((q1 * quality_penalty) as i64) as f64,
+        }
+    }
+}
+
 pub fn crafting_level(job_level: i64) -> i64 {
     if job_level <= 50 {
         job_level

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,10 +108,10 @@ mod test {
     #[test]
     fn test_available_actions() {
         let params_str = r#"{"player":{"job_level":80,"craftsmanship":2978,"control":2787,"max_cp":655,"unavailable_actions":[]},"item":{"recipe_level":516,"max_durability":55,"max_progress":12046,"max_quality":81447}}"#;
-        let state_str = r#"{"durability":55,"progress":0,"quality":0,"cp":655,"condition":"NORMAL","inner_quiet":0,"innovation":0,"veneration":0,"muscle_memory":0,"waste_not":0,"great_strides":0,"final_appraisal":0,"manipulation":0,"standard_touch_ready":false,"advanced_touch_ready":false,"turn":1,"result":"ONGOING"}"#;
+        let state_str = r#"{"durability":55,"progress":0,"quality":0,"cp":655,"condition":"NORMAL","inner_quiet":0,"innovation":0,"veneration":0,"muscle_memory":0,"waste_not":0,"great_strides":0,"final_appraisal":0,"manipulation":0,"expedience":0,"trained_perfection":0,"standard_touch_ready":false,"advanced_touch_ready":false,"trained_perfection_remain":1,"turn":1,"prev_action":null,"result":"ONGOING"}"#;
         let actual_string = available_actions(params_str, state_str);
         let mut actual: Vec<CraftAction> = serde_json::from_str(&actual_string).unwrap();
-        let mut expected = vec![BasicSynthesis, BasicTouch, MastersMend, DelicateSynthesis, CarefulSynthesis, Groundwork, Observe, PreparatoryTouch, RapidSynthesis, HastyTouch, Innovation, Veneration, MuscleMemory, StandardTouch, Reflect, WasteNot, WasteNotII, PrudentTouch, GreatStrides, FinalAppraisal, Manipulation];
+        let mut expected = vec![BasicSynthesis, BasicTouch, MastersMend, DelicateSynthesis, CarefulSynthesis, Groundwork, Observe, PreparatoryTouch, RapidSynthesis, HastyTouch, Innovation, Veneration, MuscleMemory, StandardTouch, Reflect, WasteNot, WasteNotII, PrudentTouch, GreatStrides, FinalAppraisal, Manipulation, AdvancedTouch];
         actual.sort();
         expected.sort();
         assert_eq!(actual, expected);
@@ -120,8 +120,8 @@ mod test {
     #[test]
     fn test_search_best_move() {
         let params_str = r#"{"player":{"job_level":80,"craftsmanship":2978,"control":2787,"max_cp":655,"unavailable_actions":[]},"item":{"recipe_level":516,"max_durability":55,"max_progress":5059,"max_quality":15474}}"#;
-        let state_str = r#"{"durability":55,"progress":0,"quality":0,"cp":655,"condition":"NORMAL","inner_quiet":0,"innovation":0,"veneration":0,"muscle_memory":0,"waste_not":0,"great_strides":0,"final_appraisal":0,"manipulation":0,"standard_touch_ready":false,"advanced_touch_ready":false,"turn":1,"result":"ONGOING"}"#;
+        let state_str = r#"{"durability":55,"progress":0,"quality":0,"cp":655,"condition":"NORMAL","inner_quiet":0,"innovation":0,"veneration":0,"muscle_memory":0,"waste_not":0,"great_strides":0,"final_appraisal":0,"manipulation":0,"expedience":0,"trained_perfection":0,"standard_touch_ready":false,"advanced_touch_ready":false,"trained_perfection_remain":1,"turn":1,"prev_action":null,"result":"ONGOING"}"#;
         let actual_string = search_best_move(params_str, state_str);
-        println!("{}", actual_string)
+        println!("best move: {}", actual_string)
     }
 }

--- a/src/macroplan.rs
+++ b/src/macroplan.rs
@@ -3,7 +3,8 @@ use std::{ops::Range};
 
 use crate::state::{CraftParameter, CraftState, CraftResult, StatusCondition};
 use crate::action::CraftAction;
-use rand::{thread_rng, Rng, prelude::SliceRandom};
+use crate::factor::Factors;
+use rand::{thread_rng, Rng, SeedableRng, prelude::SliceRandom, rngs::SmallRng};
 use serde::{Serialize, Deserialize};
 
 #[derive(Debug, Deserialize, Clone)]
@@ -36,8 +37,12 @@ fn actual_objective(params: &CraftParameter, state: &CraftState, actions: &Vec<C
 }
 
 pub fn run_macro(params: &CraftParameter, actions: &Vec<CraftAction>, initial_quality: i64, force_normal: bool) -> CraftState {
-    let mut state = params.initial_state(initial_quality);
     let mut rng = thread_rng();
+    run_macro_with_rng(params, &Factors::new(params), actions, initial_quality, force_normal, &mut rng)
+}
+
+fn run_macro_with_rng<R: Rng>(params: &CraftParameter, factors: &Factors, actions: &[CraftAction], initial_quality: i64, force_normal: bool, rng: &mut R) -> CraftState {
+    let mut state = params.initial_state(initial_quality);
 
     for turn in 0..actions.len() {
         if state.result != CraftResult::ONGOING {
@@ -49,7 +54,15 @@ pub fn run_macro(params: &CraftParameter, actions: &Vec<CraftAction>, initial_qu
             state.turn += 1;
             continue;
         }
-        let next_states = next_action.play(&params, &state);
+        if force_normal {
+            // The condition is about to be pinned to NORMAL anyway, which makes
+            // the whole turn deterministic for all but three actions.
+            if let Some(next_state) = next_action.play_normal(params, factors, &state) {
+                state = next_state;
+                continue;
+            }
+        }
+        let next_states = next_action.play_with(&params, factors, &state);
 
         let choice: f64 = rng.gen();
         let mut accumulate: f64 = 0.;
@@ -69,7 +82,7 @@ pub fn run_macro(params: &CraftParameter, actions: &Vec<CraftAction>, initial_qu
     state
 }
 
-fn available_actions(params: &CraftParameter) -> Vec<CraftAction> {
+pub(crate) fn available_actions(params: &CraftParameter) -> Vec<CraftAction> {
     CraftAction::all_actions().into_iter()
         .filter(|action| params.player.job_level >= action.action_level())
         .filter(|action| *action != CraftAction::TrickOfTheTrade)
@@ -83,16 +96,15 @@ fn available_actions(params: &CraftParameter) -> Vec<CraftAction> {
         .collect()
 }
 
-fn tweak(params: &CraftParameter, actions: &Vec<CraftAction>, state: &CraftState, annealing_params: &AnnealingParams) -> Vec<CraftAction> {
-    let mut rng = thread_rng();
+pub(crate) fn tweak<R: Rng>(available: &[CraftAction], actions: &[CraftAction], state: &CraftState, annealing_params: &AnnealingParams, rng: &mut R, new_actions: &mut Vec<CraftAction>) {
     let choice: f64 = rng.gen();
-    let mut new_actions = vec![];
+    new_actions.clear();
     let effective_length = actions.len().min(state.turn as usize);
     if actions.len() < 43 && (choice < annealing_params.add_proba || actions.is_empty()) {
         // add
         let position = rng.gen_range(0..(effective_length + 1));
-        let new_action = *available_actions(params).choose(&mut rng).unwrap();
-        
+        let new_action = *available.choose(rng).unwrap();
+
         new_actions.extend_from_slice(&actions[..position]);
         new_actions.push(new_action);
         new_actions.extend_from_slice(&actions[position..]);
@@ -125,13 +137,12 @@ fn tweak(params: &CraftParameter, actions: &Vec<CraftAction>, state: &CraftState
     } else {
         // replace
         let position = rng.gen_range(0..effective_length.max(1));
-        let new_action = *available_actions(params).choose(&mut rng).unwrap();
+        let new_action = *available.choose(rng).unwrap();
 
         new_actions.extend_from_slice(&actions[..position]);
         new_actions.push(new_action);
         new_actions.extend_from_slice(&actions[(position + 1)..]);
     }
-    return new_actions;
 }
 
 pub fn plan(orig_params: &CraftParameter, initial_quality: i64, longer: bool) -> Vec<CraftAction> {
@@ -158,10 +169,15 @@ pub fn plan_with_annealing_params(orig_params: &CraftParameter, initial_quality:
     params.item.max_quality = (params.item.max_quality as f64 * annealing_params.max_quality_scaling) as i64;
     let steps = annealing_params.steps;
 
-    let mut actions: Vec<CraftAction> = vec![];
-    let mut state = run_macro(params, &actions, initial_quality, true);
+    // hoisted out of the annealing loop: these depend only on params
+    let available = available_actions(params);
+    let factors = Factors::new(params);
+    let mut rng = SmallRng::from_entropy();
+
+    let mut actions: Vec<CraftAction> = Vec::with_capacity(64);
+    let mut new_actions: Vec<CraftAction> = Vec::with_capacity(64);
+    let mut state = run_macro_with_rng(params, &factors, &actions, initial_quality, true, &mut rng);
     let mut score = annealing_objective(params, &state, &actions);
-    let mut rng = thread_rng();
     let mut best_actions = actions.clone();
     let mut best_score = actual_objective(params, &state, &actions);
     for step in 0..steps {
@@ -172,18 +188,20 @@ pub fn plan_with_annealing_params(orig_params: &CraftParameter, initial_quality:
             report(params, &best_actions, initial_quality, true);
             println!("");
         }
-        let new_actions = tweak(params, &actions, &state, &annealing_params);
-        state = run_macro(params, &new_actions, initial_quality, true);
+        tweak(&available, &actions, &state, &annealing_params, &mut rng, &mut new_actions);
+        state = run_macro_with_rng(params, &factors, &new_actions, initial_quality, true, &mut rng);
         let new_score = annealing_objective(params, &state, &new_actions);
         let new_actual_score = actual_objective(params, &state, &new_actions);
-        if new_score > score || rng.gen::<f64>() < ((new_score - score) / temperature).exp() {
-            score = new_score;
-            actions = new_actions.clone();
-        }
         if new_actual_score > best_score {
             // println!("best score updated (step: {}): {} -> {}", step, best_score, new_actual_score);
             best_score = new_actual_score;
-            best_actions = new_actions.clone();
+            best_actions.clone_from(&new_actions);
+        }
+        if new_score > score || rng.gen::<f64>() < ((new_score - score) / temperature).exp() {
+            score = new_score;
+            // `new_actions` is rebuilt from scratch by `tweak`, so swapping the
+            // buffers instead of cloning keeps both allocations alive and reused.
+            swap(&mut actions, &mut new_actions);
         }
     }
     return post_process(params, initial_quality, &best_actions);

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use wasm_timer::Instant;
 
 use crate::state::{CraftParameter, CraftState, CraftResult, StatusCondition};
+use crate::factor::Factors;
 use crate::action::{CraftAction, buff_turns, ProbabilisticResult, ProbabilisticState};
 use crate::action::CraftAction::{BasicSynthesis, BasicTouch, MastersMend, Manipulation, Veneration, StandardTouch, Observe, Innovation, RapidSynthesis, ByregotBlessing, PreparatoryTouch, HastyTouch, PreciseTouch, GreatStrides, PrudentTouch, FinalAppraisal, WasteNot, WasteNotII, AdvancedTouch, TrainedFinesse};
 
@@ -23,15 +24,15 @@ pub fn terminal_score(params: &CraftParameter, state: &CraftState) -> f64 {
     }
 }
 
-fn is_positive_durability_after_action(params: &CraftParameter, state: &CraftState, action: CraftAction) -> bool {
-    action.apply(params, &state).iter().all(|proba_state| proba_state.state.durability > 0)
+fn is_positive_durability_after_action(params: &CraftParameter, factors: &Factors, state: &CraftState, action: CraftAction) -> bool {
+    action.apply_with(params, factors, &state).iter().all(|proba_state| proba_state.state.durability > 0)
 }
 
-pub fn playout(params: &CraftParameter, state: &CraftState) -> CraftState {
+pub fn playout(params: &CraftParameter, factors: &Factors, state: &CraftState) -> CraftState {
     let mut state = state.clone();
     while state.result == CraftResult::ONGOING {
-        let synthesis_playable = is_positive_durability_after_action(params, &state, BasicSynthesis);
-        let touch_playable = BasicTouch.is_playable(&params, &state) && is_positive_durability_after_action(params, &state, BasicTouch);
+        let synthesis_playable = is_positive_durability_after_action(params, factors, &state, BasicSynthesis);
+        let touch_playable = BasicTouch.is_playable(&params, &state) && is_positive_durability_after_action(params, factors, &state, BasicTouch);
         let mend_playable = MastersMend.is_playable(&params, &state);
         let action: CraftAction;
         if !(synthesis_playable || touch_playable || mend_playable) {
@@ -42,7 +43,7 @@ pub fn playout(params: &CraftParameter, state: &CraftState) -> CraftState {
             action = Manipulation
         } else {
             let calc_synthesis_progress = |state: &CraftState| {
-                BasicSynthesis.play(params, &state).get(0).unwrap().state.progress
+                BasicSynthesis.play_with(params, factors, &state).get(0).unwrap().state.progress
             };
             let synthesis_progress = calc_synthesis_progress(&state);
             if synthesis_playable && state.progress < synthesis_progress && synthesis_progress < params.item.max_progress {
@@ -75,16 +76,16 @@ pub fn playout(params: &CraftParameter, state: &CraftState) -> CraftState {
             }
         }
 
-        state = action.play(params, &state).get(0).unwrap().state.clone();
+        state = action.play_with(params, factors, &state).get(0).unwrap().state.clone();
         state.condition = StatusCondition::NORMAL;
     }
     return state
 }
 
-fn is_completable(params: &CraftParameter, state: &CraftState) -> bool {
+fn is_completable(params: &CraftParameter, factors: &Factors, state: &CraftState) -> bool {
     let mut state = state.clone();
     state.final_appraisal = 0;
-    RapidSynthesis.play(params, &state).iter().any(|proba_state| proba_state.state.result == CraftResult::SUCCESS)
+    RapidSynthesis.play_with(params, factors, &state).iter().any(|proba_state| proba_state.state.result == CraftResult::SUCCESS)
 }
 
 fn is_quality_action(action: &CraftAction) -> bool {
@@ -96,7 +97,7 @@ fn is_quality_action(action: &CraftAction) -> bool {
     }
 }
 
-fn is_meaningful_action(params: &CraftParameter, state: &CraftState, action: &CraftAction) -> bool {
+fn is_meaningful_action(params: &CraftParameter, factors: &Factors, state: &CraftState, action: &CraftAction) -> bool {
     if is_quality_action(action) {
         return state.quality < params.item.max_quality
     }
@@ -104,7 +105,7 @@ fn is_meaningful_action(params: &CraftParameter, state: &CraftState, action: &Cr
         FinalAppraisal => state.final_appraisal <= 0,
         BasicTouch => state.prev_action != Some(BasicTouch) && state.prev_action != Some(StandardTouch),
         StandardTouch => state.prev_action != Some(StandardTouch),
-        RapidSynthesis => RapidSynthesis.play(params, state).iter().all(|proba_state| proba_state.state.progress < params.item.max_progress),
+        RapidSynthesis => RapidSynthesis.play_with(params, factors, state).iter().all(|proba_state| proba_state.state.progress < params.item.max_progress),
         Veneration => buff_turns(state, 4) > state.veneration,
         Innovation => buff_turns(state, 4) > state.innovation,
         Manipulation => buff_turns(state, 8) > state.manipulation,
@@ -130,10 +131,12 @@ pub fn adaptive_dfs(params: &CraftParameter, state: &CraftState) -> DFSResult {
 
 pub fn dfs(params: &CraftParameter, state: &CraftState, depth: i64) -> DFSResult {
     let mut memo: HashMap<CraftState, DFSResult> = HashMap::new();
-    _dfs(params, state, depth, &mut memo)
+    // computed once per search rather than per simulated action
+    let factors = Factors::new(params);
+    _dfs(params, &factors, state, depth, &mut memo)
 }
 
-fn _dfs(params: &CraftParameter, state: &CraftState, depth: i64, memo: &mut HashMap<CraftState, DFSResult>) -> DFSResult {
+fn _dfs(params: &CraftParameter, factors: &Factors, state: &CraftState, depth: i64, memo: &mut HashMap<CraftState, DFSResult>) -> DFSResult {
     if memo.contains_key(state) {
         return memo.get(state).unwrap().clone()
     }
@@ -146,7 +149,7 @@ fn _dfs(params: &CraftParameter, state: &CraftState, depth: i64, memo: &mut Hash
         return result
     }
     if depth == 0 {
-        let terminal_state = playout(params, state);
+        let terminal_state = playout(params, factors, state);
         let result = DFSResult {
             best_score: terminal_score(params, &terminal_state),
             best_action_path: vec![]
@@ -154,7 +157,7 @@ fn _dfs(params: &CraftParameter, state: &CraftState, depth: i64, memo: &mut Hash
         memo.insert(state.clone(), result.clone());
         return result
     }
-    let is_completable_state = is_completable(params, state);
+    let is_completable_state = is_completable(params, factors, state);
     let actions: Vec<CraftAction> = CraftAction::all_actions().into_iter()
         .filter(|action| action.is_playable(params, state))
         .filter(|action| is_completable_state || !is_quality_action(action))
@@ -163,10 +166,10 @@ fn _dfs(params: &CraftParameter, state: &CraftState, depth: i64, memo: &mut Hash
     let mut results: Vec<DFSResult> = vec![];
     let mut best_score = 0.;
     for action in actions {
-        if !is_meaningful_action(params, state, &action) {
+        if !is_meaningful_action(params, factors, state, &action) {
             continue
         }
-        let next_states = action.play(params, state);
+        let next_states = action.play_with(params, factors, state);
         let mut next_search_states: ProbabilisticResult;
         if action != Observe {
             let next_condition = if action == CraftAction::FinalAppraisal {
@@ -200,7 +203,7 @@ fn _dfs(params: &CraftParameter, state: &CraftState, depth: i64, memo: &mut Hash
         let mut sub_results: Vec<DFSResult> = vec![];
         for proba_state in next_search_states {
             let next_depth =  depth - 1;
-            let sub_result = _dfs(params, &proba_state.state, next_depth, memo);
+            let sub_result = _dfs(params, factors, &proba_state.state, next_depth, memo);
             score += sub_result.best_score * proba_state.probability;
             upper_bound -= (1. - sub_result.best_score) * proba_state.probability;
             sub_results.push(sub_result);


### PR DESCRIPTION
焼きなましの1ステップの約80%が `run_macro` で、その `run_macro` は結果に影響しない処理に大半を使っていました。

計測 → 最適化 → 再計測で進めています。ベンチは `src/bench.rs`（`cargo run --release --bin bench`）。

## 結果

`macro_experiment`（1M steps）、解の質は不変（success rate 1.000、average quality 0.85〜0.88）:

| | before | after | 倍率 |
|---|---|---|---|
| end-to-end | 13.7 / 11.2 / 14.8 s | **2.0 / 1.9 / 1.6 s** | ~6x |
| 焼きなまし1ステップ | 15.4〜19.5 µs | **2.1〜2.7 µs** | ~6x |
| `run_macro`（19手） | 646〜744 ns/turn | **62〜78 ns/turn** | ~10x |
| 1ターン (`play` → `play_normal`) | 666〜903 ns | **31〜37 ns** | ~22x |
| DFS (`dfs` depth=4) | 1.11〜1.25 s | **0.91〜1.08 s** | ~1.2x |

## 何をしたか

**1. 焼きなまし内のシミュレーションは決定的だった**

`available_actions` は失敗しうるアクションを全て除外していて、`run_macro(force_normal = true)` は毎ターン condition を NORMAL に上書きします。`tick` が返す複数状態は **`condition` フィールドだけが違う**ので、その中からサンプリングする処理は結果に一切影響していませんでした。それなのに1ターンあたり HashMap 生成 + `sort_by_key` + Vec 3本 + `CraftState` clone 7回のコストを払っていました。

`play_normal` / `tick_normal` が同じ結果を**アロケーションゼロ**で返します。

**2. params 依存の定数を事前計算**

`progress_div` / `progress_mod` / `quality_div` / `quality_mod` / `crafting_level` は `CraftParameter` にしか依存しないのに、`produce_progress` / `produce_quality` が毎ターン引いていました（1ターン3〜6回の SipHash ルックアップ）。`Factors` として1回だけ計算して渡します。

**ロジックの重複は作っていません。** `apply_*` を `&mut CraftState` を取る形に変え、確率パスと決定パスの両方が `apply_effect` を通ります。`binary_result_states` は `success_probability` に置き換えたので、失敗しうる3アクションも「確率が1未満」というだけで別コードパスではありません。今後のパッチ対応で片方だけ更新し忘れる、という事故が起きない形にしてあります。

## 正しさの確認

- **`play_normal_matches_every_outcome_of_play`**: 5種のパラメータ（expert レシピ 641 / 516 を含む）でランダムなマクロを歩き、`play` が返す**全ての**結果が condition を NORMAL に潰すと `play_normal` と一致することを1万ターン以上で検証
- `run_macro` を同じマクロで200,000回まわした quality 合計が最適化前と**完全に同一**
- DFS の探索結果が一致（`MuscleMemory`、score 0.679473）

## 補足

- `apply()` に `Factors` 構築を入れた結果、一度 DFS が18%遅くなりました（1回3ルックアップで済んでいたアクションが5回払うため）。`search.rs` にも `Factors` を通して、最終的に master より速くなっています
- `lib.rs` の2つのテストは**このPR以前から失敗**していました。JSON フィクスチャに `expedience` / `trained_perfection` 等が無く、期待値リストに Advanced Touch（Lv68 で使用可）が漏れていたためです。DFS の回帰確認に必要だったので直しました
- `log-consistency-test` の4件の失敗は master でも同じなので触っていません

## 未確認

**ブラウザでの wasm 実測をしていません**（手元に node / wasm-pack がないため）。消したのは HashMap(SipHash) とヒープアロケーションで、これは wasm の方が相対的に高コスト（dlmalloc）なので6倍を下回るとは考えにくいですが、マージ前に確認をおすすめします。

なお `opt-level = 3` + LTO + `codegen-units = 1` も試しましたが**改善しませんでした**（13.0s → 15.4s）。ボトルネックはコード生成品質ではないので、`opt-level = "s"` は据え置きです。

## 次にやるなら

`run_macro` が1ステップの約55%まで下がり、相対的に `tweak`（76 ns、約3%）が見えてきました。残る候補は、決定的になったことで可能になった**プレフィックス状態のキャッシュ**（さらに約2倍）と、**`CraftState` の縮小**（i64×18 で約160B → 40B、wasm で効きやすい）です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
